### PR TITLE
Add Partial String Support

### DIFF
--- a/Plugins/WebSocket.jslib
+++ b/Plugins/WebSocket.jslib
@@ -168,7 +168,20 @@ var LibraryWebSocket = {
 					_free(buffer);
 				}
 
+			} else if (typeof ev.data == 'string') {
+				var arrBuffer = new ArrayBuffer(ev.data.length)
+				var dataBuffer = new Uint8Array(arrBuffer)
+				for (var i = 0, len = ev.data.length; i < len; i++) {
+				  dataBuffer[i] = ev.data.charCodeAt(i)
+				}
+				var buffer = _malloc(dataBuffer.length);
+				HEAPU8.set(dataBuffer, buffer);
+				try {
+				Runtime.dynCall("viii", webSocketState.onMessage, [ instanceId, buffer, dataBuffer.length ]);
+				} finally {
+				_free(buffer);
 			}
+      }
 
 		};
 


### PR DESCRIPTION
Incoming WebSocket messages formatted as Strings can now be read. The Unity script side will still need to handle the response as a byte array and parsing String WS messages will be less efficient than binary messages.