### PR TITLE
Use UTF8ToString instead of Pointer_stringify, and Module['dynCall_*'] instead of Runtime.dynCall

### DIFF
--- a/Plugins/WebSocket.jslib
+++ b/Plugins/WebSocket.jslib
@@ -83,7 +83,7 @@ var LibraryWebSocket = {
 	 */
 	WebSocketAllocate: function(url) {
 
-		var urlStr = Pointer_stringify(url);
+		var urlStr = UTF8ToString(url);
 		var id = webSocketState.lastId++;
 
 		webSocketState.instances[id] = {
@@ -143,7 +143,7 @@ var LibraryWebSocket = {
 				console.log("[JSLIB WebSocket] Connected.");
 
 			if (webSocketState.onOpen)
-				Runtime.dynCall('vi', webSocketState.onOpen, [ instanceId ]);
+				Module['dynCall_vi'](webSocketState.onOpen, [ instanceId ]);
 
 		};
 
@@ -163,7 +163,7 @@ var LibraryWebSocket = {
 				HEAPU8.set(dataBuffer, buffer);
 
 				try {
-					Runtime.dynCall('viii', webSocketState.onMessage, [ instanceId, buffer, dataBuffer.length ]);
+					Module['dynCall_viii']( webSocketState.onMessage, [ instanceId, buffer, dataBuffer.length ]);
 				} finally {
 					_free(buffer);
 				}
@@ -185,7 +185,7 @@ var LibraryWebSocket = {
 				stringToUTF8(msg, msgBuffer, msgBytes);
 
 				try {
-					Runtime.dynCall('vii', webSocketState.onError, [ instanceId, msgBuffer ]);
+					Module['dynCall_vii']( webSocketState.onError, [ instanceId, msgBuffer ]);
 				} finally {
 					_free(msgBuffer);
 				}
@@ -200,7 +200,7 @@ var LibraryWebSocket = {
 				console.log("[JSLIB WebSocket] Closed.");
 
 			if (webSocketState.onClose)
-				Runtime.dynCall('vii', webSocketState.onClose, [ instanceId, ev.code ]);
+				Module['dynCall_vii']( webSocketState.onClose, [ instanceId, ev.code ]);
 
 			delete instance.ws;
 
@@ -231,7 +231,7 @@ var LibraryWebSocket = {
 		if (instance.ws.readyState === 3)
 			return -5;
 
-		var reason = ( reasonPtr ? Pointer_stringify(reasonPtr) : undefined );
+		var reason = ( reasonPtr ? UTF8ToString(reasonPtr) : undefined );
 		
 		try {
 			instance.ws.close(code, reason);


### PR DESCRIPTION
In Unity 2021.3.0f1 LTS, these changes are needed to avoid runtime errors in WebGL build